### PR TITLE
Fix indenting in web.md markdown

### DIFF
--- a/docs/build/web.md
+++ b/docs/build/web.md
@@ -101,42 +101,43 @@ Q: unittest fails on Debug build with debug info.
 
 1. Install NPM packages
 
-   1. in `<ORT_ROOT>/js/`, run `npm ci`.
-   2. in `<ORT_ROOT>/js/common/`, run `npm ci`.
-   3. in `<ORT_ROOT>/js/web/`, run `npm ci`.
+    1. in `<ORT_ROOT>/js/`, run `npm ci`.
+    2. in `<ORT_ROOT>/js/common/`, run `npm ci`.
+    3. in `<ORT_ROOT>/js/web/`, run `npm ci`.
 
 2. Prepare ONNX Runtime WebAssembly artifacts.
 
-   You can either use the prebuilt artifacts or build it by yourself.
+    You can either use the prebuilt artifacts or build it by yourself.
 
-   - Setup by script.
+    - Setup by script.
 
-     In `<ORT_ROOT>/js/web/`, run `npm run pull:wasm` to pull WebAssembly artifacts for latest master branch from CI pipeline.
+      In `<ORT_ROOT>/js/web/`, run `npm run pull:wasm` to pull WebAssembly artifacts for latest master branch from CI pipeline.
 
-   - Download artifacts from pipeline manually.
+    - Download artifacts from pipeline manually.
 
-     you can download prebuilt WebAssembly artifacts from [Windows WebAssembly CI Pipeline](https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=161&_a=summary). Select a build, download artifact "Release_wasm" and unzip. See instructions below to put files into destination folders.
+      You can download prebuilt WebAssembly artifacts from [Windows WebAssembly CI Pipeline](https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=161&_a=summary). Select a build, download artifact "Release_wasm" and unzip. See instructions below to put files into destination folders.
 
-   - Build WebAssembly artifacts.
+    - Build WebAssembly artifacts.
 
-     1. Build ONNX Runtime WebAssembly
+      1. Build ONNX Runtime WebAssembly
 
-        Follow [instructions above](#build-onnx-runtime-for-webassembly) for building ONNX Runtime WebAssembly.
+         Follow [instructions above](#build-onnx-runtime-for-webassembly) for building ONNX Runtime WebAssembly.
 
-     2. Copy following files from build output folder to `<ORT_ROOT>/js/web/dist/` (create the folder if it does not exist):
+      2. Copy following files from build output folder to `<ORT_ROOT>/js/web/dist/` (create the folder if it does not exist):
 
-         * ort-wasm.wasm
-         * ort-wasm-threaded.wasm (build with flag '--enable_wasm_threads')
-         * ort-wasm-simd.wasm (build with flag '--enable_wasm_simd')
-         * ort-wasm-simd-threaded.wasm (build with flags '--enable_wasm_threads --enable_wasm_simd')
+          * ort-wasm.wasm
+          * ort-wasm-threaded.wasm (build with flag '--enable_wasm_threads')
+          * ort-wasm-simd.wasm (build with flag '--enable_wasm_simd')
+          * ort-wasm-simd-threaded.wasm (build with flags '--enable_wasm_threads --enable_wasm_simd')
 
-     3. Copy following files from build output folder to `<ORT_ROOT>/js/web/lib/wasm/binding/`:
+      3. Copy following files from build output folder to `<ORT_ROOT>/js/web/lib/wasm/binding/`:
 
-         * ort-wasm.js
-         * ort-wasm-threaded.js (build with flag '--enable_wasm_threads')
-         * ort-wasm-threaded.worker.js (build with flag '--enable_wasm_threads')
+          * ort-wasm.js
+          * ort-wasm-threaded.js (build with flag '--enable_wasm_threads')
+          * ort-wasm-threaded.worker.js (build with flag '--enable_wasm_threads')
 
-3. Use following command in folder `<ORT_ROOT>/js/web` to build:
+3. Use the following command in folder `<ORT_ROOT>/js/web` to build:
+
    ```
    npm run build
    ```


### PR DESCRIPTION
**Description**:  the kramdown markdown parser requires 4 spaces for nested lists 
